### PR TITLE
gesture: fix possible race during initialization

### DIFF
--- a/services/java/com/android/server/gesture/EdgeGestureService.java
+++ b/services/java/com/android/server/gesture/EdgeGestureService.java
@@ -185,19 +185,21 @@ public class EdgeGestureService extends IEdgeGestureService.Stub {
     public void systemReady() {
         if (DEBUG) Slog.d(TAG, "Starting the edge gesture capture thread ...");
 
-        mHandlerThread.start();
-        mHandler = new H(mHandlerThread.getLooper());
-        mHandler.post(new Runnable() {
-            @Override
-            public void run() {
-                android.os.Process.setThreadPriority(
-                        android.os.Process.THREAD_PRIORITY_FOREGROUND);
-                android.os.Process.setCanSelfBackground(false);
-            }
-        });
-        mDisplayObserver = new DisplayObserver(mContext, mHandler);
-        // check if anyone registered during startup
-        mHandler.sendEmptyMessage(MSG_UPDATE_SERVICE);
+        synchronized (mLock) {
+            mHandlerThread.start();
+            mHandler = new H(mHandlerThread.getLooper());
+            mHandler.post(new Runnable() {
+                @Override
+                public void run() {
+                    android.os.Process.setThreadPriority(
+                            android.os.Process.THREAD_PRIORITY_FOREGROUND);
+                    android.os.Process.setCanSelfBackground(false);
+                }
+            });
+            mDisplayObserver = new DisplayObserver(mContext, mHandler);
+            // check if anyone registered during startup
+            mHandler.sendEmptyMessage(MSG_UPDATE_SERVICE);
+        }
     }
 
 


### PR DESCRIPTION
It's possible for binder events to fire before mDisplayObserver is
setup. Take mLock during the setup phase to prevent access to
mDisplayObserver until setup completes.

SAMBAR-1121

Change-Id: I8c137ead7d0f956faca134be565b6db1da680f76
